### PR TITLE
feat: ローカルLLM統合疲労判断 + WebSocketリモートストリーミング + ロボットアーム連携

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 """Central configuration: model paths, class labels, normalization parameters."""
 
+import os
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -74,3 +75,18 @@ NEGATIVE_KEYWORDS: dict[str, float] = {
     "集中できない": 0.6,
     "頭痛い": 0.8,
 }
+
+# ---------------------------------------------------------------------------
+# LLM Fatigue Scorer (Ollama)
+# ---------------------------------------------------------------------------
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+LLM_MODEL = os.getenv("LLM_MODEL", "qwen3:8b")
+LLM_TIMEOUT = float(os.getenv("LLM_TIMEOUT", "5.0"))
+LLM_WINDOW_SIZE = int(os.getenv("LLM_WINDOW_SIZE", "5"))
+ENABLE_LLM_SCORING = os.getenv("ENABLE_LLM_SCORING", "true").lower() == "true"
+
+# ---------------------------------------------------------------------------
+# Robot arm trigger (SO-ARM101)
+# ---------------------------------------------------------------------------
+ARM_SERVER_URL = os.getenv("ARM_SERVER_URL", "http://localhost:8766")
+FATIGUE_ARM_THRESHOLD = float(os.getenv("FATIGUE_ARM_THRESHOLD", "0.7"))

--- a/app/inference/audio.py
+++ b/app/inference/audio.py
@@ -113,3 +113,97 @@ class AudioSpeechAnalyzer:
         if self._stream.active:
             self._stream.stop()
         self._stream.close()
+
+
+class AudioBufferAnalyzer:
+    """WebSocket audio chunk analyzer — no sounddevice dependency.
+
+    Accepts WebM/Opus binary chunks pushed from a WebSocket connection,
+    decodes them via ffmpeg, and runs the same faster-whisper + keyword
+    pipeline as ``AudioSpeechAnalyzer``.
+    """
+
+    def __init__(self) -> None:
+        self._model = WhisperModel(
+            WHISPER_MODEL_SIZE,
+            device=WHISPER_DEVICE,
+            compute_type=WHISPER_COMPUTE_TYPE,
+        )
+        self._raw_chunks: list[bytes] = []
+        self._raw_lock = threading.Lock()
+        self._max_chunks = 300  # ~30s at 100ms/chunk
+        self._voice_score = 0.0
+
+    def push_chunk(self, data: bytes) -> None:
+        """Append a WebM/Opus chunk from the browser MediaRecorder."""
+        with self._raw_lock:
+            self._raw_chunks.append(data)
+            if len(self._raw_chunks) > self._max_chunks:
+                self._raw_chunks.pop(0)
+
+    def analyze(self) -> dict:
+        """Decode accumulated audio, transcribe, and match keywords.
+
+        Returns the same dict shape as ``AudioSpeechAnalyzer.analyze()``.
+        """
+        pcm = self._decode_accumulated()
+        if pcm is None or len(pcm) < AUDIO_SAMPLE_RATE:
+            # Not enough audio yet — decay and return
+            self._voice_score *= VOICE_SCORE_DECAY
+            return {
+                "voice_score": self._voice_score,
+                "transcript": "",
+                "negative_detected": False,
+                "matched_keywords": [],
+            }
+
+        # Use only the last AUDIO_BUFFER_SECONDS of PCM
+        max_samples = AUDIO_SAMPLE_RATE * AUDIO_BUFFER_SECONDS
+        audio = pcm[-max_samples:]
+
+        segments, _ = self._model.transcribe(audio, language="ja", beam_size=1)
+        transcript = "".join(seg.text for seg in segments)
+
+        detected, matched, severity = AudioSpeechAnalyzer._match_keywords(transcript)
+
+        if detected:
+            self._voice_score = severity
+        else:
+            self._voice_score *= VOICE_SCORE_DECAY
+
+        return {
+            "voice_score": self._voice_score,
+            "transcript": transcript,
+            "negative_detected": detected,
+            "matched_keywords": matched,
+        }
+
+    def _decode_accumulated(self) -> np.ndarray | None:
+        """Combine all WebM chunks and decode to 16kHz mono float32 via ffmpeg."""
+        import subprocess
+
+        with self._raw_lock:
+            if not self._raw_chunks:
+                return None
+            combined = b"".join(self._raw_chunks)
+
+        try:
+            proc = subprocess.run(
+                [
+                    "ffmpeg", "-y",
+                    "-i", "pipe:0",
+                    "-f", "s16le",
+                    "-acodec", "pcm_s16le",
+                    "-ar", str(AUDIO_SAMPLE_RATE),
+                    "-ac", "1",
+                    "pipe:1",
+                ],
+                input=combined,
+                capture_output=True,
+                timeout=5.0,
+            )
+            if not proc.stdout:
+                return None
+            return np.frombuffer(proc.stdout, dtype=np.int16).astype(np.float32) / 32768.0
+        except Exception:
+            return None

--- a/app/inference/llm_fatigue.py
+++ b/app/inference/llm_fatigue.py
@@ -1,0 +1,248 @@
+"""LLM-based fatigue scoring via Ollama (local LLM on DGX Spark).
+
+Implements an "agent loop" pattern: maintains a sliding window of recent
+observations and feeds temporal context to the LLM for richer fatigue
+assessment than instantaneous rule-based scoring.
+
+Falls back to the existing rule-based FatigueScorer when Ollama is
+unavailable or times out.
+"""
+
+import json
+import logging
+import time
+from collections import deque
+from datetime import datetime, timezone
+
+import requests
+
+from app.inference.fatigue import FatigueScorer
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+あなたはオフィスワーカーの疲労度を評価するAIです。
+複数のセンサーから得られたデータの時系列を分析し、総合的な疲労スコアを出力してください。
+
+## 評価基準
+- 姿勢が悪化傾向にある場合、疲労が蓄積していると判断
+- ネガティブな発言は疲労の強いシグナル
+- 環境ストレス（CO2上昇・気温偏差・換気不良）は疲労を助長する
+- 複数要因が同時に悪化している場合はシナジー効果で高めに評価
+
+## 出力形式
+以下のJSON形式のみで回答してください。他のテキストは含めないでください。
+{"fatigue_score": 0.0, "reasoning": "判断理由を1文で"}
+
+fatigue_score は 0.0（元気）〜 1.0（極度の疲労）の範囲です。\
+"""
+
+_POSTURE_LABELS = {
+    "good": "良好",
+    "slouch": "猫背",
+    "chin_rest": "頬杖",
+    "stretch": "ストレッチ",
+}
+
+
+class LLMFatigueScorer:
+    """Agent-loop fatigue scorer backed by a local Ollama LLM.
+
+    Maintains a sliding window of recent observations and constructs a
+    temporal-context prompt for the LLM.  On failure, transparently falls
+    back to the rule-based ``FatigueScorer``.
+    """
+
+    def __init__(
+        self,
+        ollama_host: str = "http://localhost:11434",
+        model_name: str = "qwen3:8b",
+        timeout: float = 3.0,
+        window_size: int = 5,
+    ) -> None:
+        self._host = ollama_host.rstrip("/")
+        self._model = model_name
+        self._timeout = timeout
+        self._observations: deque[dict] = deque(maxlen=window_size)
+        self._fallback = FatigueScorer()
+        self._available: bool | None = None
+
+    # ------------------------------------------------------------------
+    # Health check
+    # ------------------------------------------------------------------
+    def is_available(self) -> bool:
+        """Check Ollama connectivity (cached after first call)."""
+        if self._available is None:
+            try:
+                r = requests.get(f"{self._host}/api/tags", timeout=2.0)
+                self._available = r.status_code == 200
+            except Exception:
+                self._available = False
+            logger.info("Ollama available: %s", self._available)
+        return self._available
+
+    def reset_availability(self) -> None:
+        """Force re-check on next call (e.g. after Ollama restart)."""
+        self._available = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def score(
+        self,
+        posture_result: dict,
+        airflow_result: dict,
+        voice_result: dict | None = None,
+    ) -> dict:
+        """Compute fatigue score via LLM with rule-based fallback.
+
+        Returns a dict compatible with ``FatigueScorer.compute()`` output,
+        augmented with ``llm_used``, ``llm_status``, and ``llm_reasoning``
+        keys.
+        """
+        self._add_observation(posture_result, airflow_result, voice_result)
+
+        # Always compute rule-based as baseline / fallback
+        rule_result = self._fallback.compute(
+            posture_result, airflow_result, voice_result
+        )
+
+        if not self.is_available():
+            return {**rule_result, "llm_used": False, "llm_status": "unavailable"}
+
+        prompt = self._build_prompt(posture_result, airflow_result, voice_result)
+        llm_response = self._call_ollama(prompt)
+
+        if llm_response is None:
+            return {**rule_result, "llm_used": False, "llm_status": "timeout"}
+
+        return {
+            **rule_result,
+            "fatigue_score": llm_response["fatigue_score"],
+            "llm_used": True,
+            "llm_status": "ok",
+            "llm_reasoning": llm_response.get("reasoning", ""),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _add_observation(
+        self,
+        posture_result: dict,
+        airflow_result: dict,
+        voice_result: dict | None,
+    ) -> None:
+        self._observations.append(
+            {
+                "time": time.time(),
+                "posture_class": posture_result["class"],
+                "posture_confidence": posture_result["confidence"],
+                "posture_score": self._fallback.compute_posture_score(posture_result),
+                "env_score": self._fallback.compute_environment_score(airflow_result),
+                "voice_score": voice_result["voice_score"] if voice_result else 0.0,
+                "voice_transcript": (
+                    voice_result.get("transcript", "") if voice_result else ""
+                ),
+                "voice_keywords": (
+                    voice_result.get("matched_keywords", []) if voice_result else []
+                ),
+            }
+        )
+
+    def _build_prompt(
+        self,
+        posture_result: dict,
+        airflow_result: dict,
+        voice_result: dict | None,
+    ) -> str:
+        now = time.time()
+        lines: list[str] = []
+
+        # Observation history
+        if len(self._observations) > 1:
+            lines.append("## 直近の観測履歴")
+            for i, obs in enumerate(self._observations):
+                elapsed = int(now - obs["time"])
+                posture_ja = _POSTURE_LABELS.get(
+                    obs["posture_class"], obs["posture_class"]
+                )
+                voice_info = "なし"
+                if obs["voice_score"] > 0.1:
+                    kw = ", ".join(obs["voice_keywords"]) if obs["voice_keywords"] else ""
+                    voice_info = f"スコア{obs['voice_score']:.1f}"
+                    if kw:
+                        voice_info += f' ("{kw}")'
+                lines.append(
+                    f"[{i + 1}] {elapsed}秒前 | "
+                    f"姿勢: {posture_ja}({obs['posture_confidence']:.2f}) | "
+                    f"音声: {voice_info} | "
+                    f"環境ストレス: {obs['env_score']:.2f}"
+                )
+            lines.append("")
+
+        # Current state
+        current = self._observations[-1]
+        posture_ja = _POSTURE_LABELS.get(
+            current["posture_class"], current["posture_class"]
+        )
+        lines.append("## 現在の状態")
+        lines.append(
+            f"姿勢: {posture_ja} (信頼度{current['posture_confidence']:.2f}, "
+            f"姿勢スコア{current['posture_score']:.2f})"
+        )
+
+        voice_desc = "なし"
+        if voice_result and voice_result["voice_score"] > 0.1:
+            voice_desc = f"スコア{voice_result['voice_score']:.1f}"
+            if voice_result.get("matched_keywords"):
+                voice_desc += f" (検出: {', '.join(voice_result['matched_keywords'])})"
+            if voice_result.get("transcript"):
+                voice_desc += f' / 発話内容: "{voice_result["transcript"]}"'
+        lines.append(f"音声: {voice_desc}")
+        lines.append(f"環境ストレス: {current['env_score']:.2f}")
+
+        return "\n".join(lines)
+
+    def _call_ollama(self, prompt: str) -> dict | None:
+        """POST to Ollama /api/generate and parse JSON response."""
+        try:
+            r = requests.post(
+                f"{self._host}/api/generate",
+                json={
+                    "model": self._model,
+                    "system": _SYSTEM_PROMPT,
+                    "prompt": prompt,
+                    "format": "json",
+                    "stream": False,
+                    "options": {
+                        "temperature": 0.1,
+                        "num_predict": 150,
+                    },
+                },
+                timeout=self._timeout,
+            )
+            r.raise_for_status()
+            raw = r.json().get("response", "")
+            return self._parse_response(raw)
+        except requests.Timeout:
+            logger.warning("Ollama request timed out (%.1fs)", self._timeout)
+            return None
+        except Exception:
+            logger.exception("Ollama request failed")
+            return None
+
+    @staticmethod
+    def _parse_response(raw: str) -> dict | None:
+        """Extract fatigue_score from LLM JSON output."""
+        try:
+            data = json.loads(raw)
+            score = float(data["fatigue_score"])
+            score = max(0.0, min(1.0, score))
+            return {
+                "fatigue_score": score,
+                "reasoning": data.get("reasoning", ""),
+            }
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+            logger.warning("Failed to parse LLM response: %s", raw[:200])
+            return None

--- a/app/main.py
+++ b/app/main.py
@@ -4,9 +4,11 @@ Usage:
     streamlit run app/main.py
 """
 
+import logging
 import os
 import sys
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 
 # Ensure project root is on sys.path so "app" package is importable
@@ -24,11 +26,20 @@ from app.inference.posture import PostureInference
 from app.inference.airflow import AirflowInference
 from app.inference.fatigue import FatigueScorer
 from app.config import (
+    ARM_SERVER_URL,
     AUDIO_ANALYZE_INTERVAL,
     DEFAULT_DESK_X,
     DEFAULT_DESK_Y,
     DEFAULT_DESK_Z,
+    ENABLE_LLM_SCORING,
+    FATIGUE_ARM_THRESHOLD,
+    LLM_MODEL,
+    LLM_TIMEOUT,
+    LLM_WINDOW_SIZE,
+    OLLAMA_HOST,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Page config
@@ -42,10 +53,29 @@ st.title("空間AIブレイン — 疲労度モニター")
 
 @st.cache_resource
 def load_models():
-    return PostureInference(), AirflowInference(), FatigueScorer()
+    posture = PostureInference()
+    airflow = AirflowInference()
+    rule_scorer = FatigueScorer()
+
+    llm_scorer = None
+    if ENABLE_LLM_SCORING:
+        from app.inference.llm_fatigue import LLMFatigueScorer
+
+        llm_scorer = LLMFatigueScorer(
+            ollama_host=OLLAMA_HOST,
+            model_name=LLM_MODEL,
+            timeout=LLM_TIMEOUT,
+            window_size=LLM_WINDOW_SIZE,
+        )
+    return posture, airflow, rule_scorer, llm_scorer
 
 
-posture_model, airflow_model, fatigue_scorer = load_models()
+posture_model, airflow_model, fatigue_scorer, llm_scorer = load_models()
+
+# Thread pool for non-blocking LLM calls
+_llm_executor = ThreadPoolExecutor(max_workers=1)
+_llm_future: Future | None = None
+_last_llm_result: dict | None = None
 
 
 @st.cache_resource
@@ -79,6 +109,36 @@ enable_voice = st.sidebar.checkbox("音声モニタリング", value=True)
 audio_analyzer = load_audio_analyzer() if enable_voice else None
 if enable_voice and audio_analyzer is None:
     st.sidebar.warning("マイク未検出 — 音声モニタリング無効")
+
+# ---------------------------------------------------------------------------
+# Sidebar — LLM scoring status
+# ---------------------------------------------------------------------------
+st.sidebar.header("LLM疲労判定")
+if llm_scorer is not None:
+    llm_enabled = st.sidebar.checkbox("LLM判定を使用", value=True)
+    if llm_enabled:
+        st.sidebar.caption(f"モデル: {LLM_MODEL} @ {OLLAMA_HOST}")
+    else:
+        st.sidebar.info("ルールベースで動作中")
+else:
+    llm_enabled = False
+    st.sidebar.info("LLM無効 (ENABLE_LLM_SCORING=false)")
+
+# ---------------------------------------------------------------------------
+# Sidebar — robot arm trigger
+# ---------------------------------------------------------------------------
+st.sidebar.header("ロボットアーム")
+trigger_arm = st.sidebar.checkbox("疲労時にアーム起動", value=False)
+if trigger_arm:
+    arm_url = st.sidebar.text_input(
+        "アームサーバーURL", value=ARM_SERVER_URL
+    )
+    arm_threshold = st.sidebar.slider(
+        "発動しきい値", 0.0, 1.0, FATIGUE_ARM_THRESHOLD, 0.05
+    )
+else:
+    arm_url = ARM_SERVER_URL
+    arm_threshold = FATIGUE_ARM_THRESHOLD
 
 # ---------------------------------------------------------------------------
 # Sidebar — optional cloud send
@@ -175,9 +235,16 @@ with col_dash:
     score_placeholder = st.empty()
     posture_placeholder = st.empty()
 
+    st.subheader("🧠 LLM判定")
+    llm_status_placeholder = st.empty()
+    llm_reasoning_placeholder = st.empty()
+
     st.subheader("音声認識")
     voice_text_placeholder = st.empty()
     voice_status_placeholder = st.empty()
+
+    st.subheader("🤖 ロボットアーム")
+    arm_status_placeholder = st.empty()
 
     st.subheader("室内環境 (AI予測)")
     env_placeholder = st.empty()
@@ -201,6 +268,9 @@ last_voice_result: dict | None = None
 last_voice_analyze = 0.0
 cloud_send_interval = 10.0  # seconds
 last_cloud_send = 0.0
+arm_triggered = False
+arm_cooldown = 30.0  # seconds between arm triggers
+last_arm_trigger = 0.0
 
 try:
     while cap.isOpened():
@@ -230,9 +300,35 @@ try:
         # Run posture inference periodically
         if frame_count % INFERENCE_INTERVAL == 0:
             last_posture = posture_model.predict(frame)
-            last_fatigue = fatigue_scorer.compute(
-                last_posture, airflow_result, last_voice_result
-            )
+
+            # --- LLM scoring (async) or rule-based ---
+            if llm_enabled and llm_scorer is not None:
+                global _llm_future, _last_llm_result
+                # Collect result from previous async call
+                if _llm_future is not None and _llm_future.done():
+                    try:
+                        _last_llm_result = _llm_future.result(timeout=0)
+                    except Exception:
+                        pass
+                # Submit new async LLM call if not in-flight
+                if _llm_future is None or _llm_future.done():
+                    _llm_future = _llm_executor.submit(
+                        llm_scorer.score,
+                        last_posture,
+                        airflow_result,
+                        last_voice_result,
+                    )
+                # Use latest LLM result, or fall back to rule-based
+                if _last_llm_result is not None:
+                    last_fatigue = _last_llm_result
+                else:
+                    last_fatigue = fatigue_scorer.compute(
+                        last_posture, airflow_result, last_voice_result
+                    )
+            else:
+                last_fatigue = fatigue_scorer.compute(
+                    last_posture, airflow_result, last_voice_result
+                )
 
             # Update dashboard
             score = last_fatigue["fatigue_score"]
@@ -245,6 +341,44 @@ try:
                 f"**姿勢**: {POSTURE_LABELS_JA.get(last_posture['class'], last_posture['class'])} "
                 f"(信頼度 {last_posture['confidence']:.0%})"
             )
+
+            # LLM status display
+            if last_fatigue.get("llm_used"):
+                llm_status_placeholder.success("✅ LLM判定使用中")
+                reasoning = last_fatigue.get("llm_reasoning", "")
+                if reasoning:
+                    llm_reasoning_placeholder.info(f"💭 {reasoning}")
+            elif llm_enabled:
+                status = last_fatigue.get("llm_status", "pending")
+                llm_status_placeholder.warning(f"⚠ ルールベース (LLM: {status})")
+                llm_reasoning_placeholder.empty()
+            else:
+                llm_status_placeholder.info("ルールベースモード")
+                llm_reasoning_placeholder.empty()
+
+            # --- Robot arm trigger ---
+            now = time.time()
+            if (
+                trigger_arm
+                and score >= arm_threshold
+                and now - last_arm_trigger > arm_cooldown
+            ):
+                last_arm_trigger = now
+                arm_status_placeholder.warning("🦾 飴ちゃん配達中...")
+                try:
+                    requests.post(
+                        f"{arm_url}/trigger",
+                        json={"fatigue_score": score},
+                        timeout=60,
+                    )
+                    arm_status_placeholder.success("✅ 飴ちゃん配達完了!")
+                except requests.RequestException as e:
+                    arm_status_placeholder.error(f"❌ アーム通信エラー: {e}")
+            elif trigger_arm:
+                if score < arm_threshold:
+                    arm_status_placeholder.info(
+                        f"待機中 (スコア {score:.2f} < しきい値 {arm_threshold:.2f})"
+                    )
 
             # Optional cloud send
             now = time.time()

--- a/app/requirements-dgx.txt
+++ b/app/requirements-dgx.txt
@@ -8,3 +8,6 @@ requests>=2.31.0
 Pillow>=10.0.0
 faster-whisper>=1.0.0
 sounddevice>=0.4.6
+fastapi>=0.115.0
+uvicorn[standard]>=0.34.0
+httpx>=0.25.0

--- a/app/static/client.html
+++ b/app/static/client.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>空間AIブレイン — 疲労度モニター</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, sans-serif; background: #1a1a2e; color: #eee; }
+  .container { max-width: 1100px; margin: 0 auto; padding: 16px; }
+  h1 { text-align: center; margin-bottom: 16px; font-size: 1.3em; }
+  h1 span { color: #ffd700; }
+
+  .layout { display: grid; grid-template-columns: 1fr 340px; gap: 16px; }
+
+  /* Video area */
+  .video-area {
+    position: relative; border-radius: 12px; overflow: hidden; background: #000;
+  }
+  video { width: 100%; display: block; transform: scaleX(-1); }
+  canvas { display: none; }
+
+  .overlay {
+    position: absolute; top: 12px; right: 12px;
+    background: rgba(0,0,0,0.75); padding: 10px 16px;
+    border-radius: 8px; font-size: 1.1em; font-weight: bold;
+    min-width: 160px; text-align: center;
+  }
+  .overlay.good { border: 2px solid #4caf50; color: #4caf50; }
+  .overlay.slouch, .overlay.chin_rest { border: 2px solid #ff5252; color: #ff5252; animation: pulse 1s infinite; }
+  .overlay.stretch { border: 2px solid #ffc107; color: #ffc107; }
+  .overlay.waiting { border: 2px solid #888; color: #888; }
+
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.6} }
+
+  /* Dashboard panel */
+  .dashboard { display: flex; flex-direction: column; gap: 12px; }
+  .panel {
+    background: #16213e; border-radius: 10px; padding: 14px;
+  }
+  .panel h3 { font-size: 0.85em; color: #aaa; margin-bottom: 8px; }
+
+  /* Score big display */
+  .big-score { font-size: 2.8em; font-weight: bold; text-align: center; }
+  .big-score.low { color: #4caf50; }
+  .big-score.mid { color: #ffc107; }
+  .big-score.high { color: #ff5252; }
+
+  /* Meters */
+  .meter { margin-bottom: 6px; }
+  .meter label { font-size: 0.75em; color: #999; }
+  .meter .bar { height: 6px; background: #333; border-radius: 3px; margin-top: 3px; overflow: hidden; }
+  .meter .bar-fill { height: 100%; border-radius: 3px; transition: width 0.3s, background 0.3s; }
+  .meter .value { font-size: 0.85em; font-weight: bold; float: right; margin-top: -18px; }
+
+  /* LLM panel */
+  .llm-reasoning {
+    font-size: 0.85em; color: #ccc; background: #0f0f23;
+    border-radius: 6px; padding: 8px; min-height: 32px;
+    border-left: 3px solid #7c4dff;
+  }
+  .llm-status { font-size: 0.75em; color: #888; margin-top: 4px; }
+
+  /* Voice panel */
+  .transcript {
+    font-size: 0.85em; color: #ccc; background: #0f0f23;
+    border-radius: 6px; padding: 8px; min-height: 24px;
+  }
+  .keyword-alert { color: #ff5252; font-weight: bold; font-size: 0.85em; margin-top: 4px; }
+
+  /* Controls */
+  .controls { display: flex; gap: 10px; justify-content: center; margin: 12px 0; }
+  button {
+    padding: 8px 20px; border: none; border-radius: 8px;
+    font-size: 0.95em; cursor: pointer; transition: 0.2s;
+  }
+  button:hover { transform: scale(1.05); }
+  #btn-start { background: #2196f3; color: #fff; }
+  #btn-stop { background: #ff5252; color: #fff; }
+
+  /* Status row */
+  .status-row {
+    display: flex; gap: 16px; justify-content: center;
+    margin-bottom: 10px; font-size: 0.8em; color: #aaa;
+  }
+  .status-row span { display: flex; align-items: center; gap: 4px; }
+  .dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
+  .dot.on { background: #4caf50; }
+  .dot.off { background: #555; }
+
+  /* Log */
+  .log {
+    background: #0f0f23; border-radius: 8px; padding: 8px;
+    max-height: 100px; overflow-y: auto; font-family: monospace;
+    font-size: 0.75em; color: #666; margin-top: 8px;
+  }
+  .log .entry { margin-bottom: 1px; }
+  .log .entry.warn { color: #ff5252; }
+  .log .entry.info { color: #4caf50; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>🍬 <span>空間AIブレイン</span> — 疲労度モニター</h1>
+
+  <div class="status-row">
+    <span><span class="dot" id="dot-video"></span> カメラ</span>
+    <span><span class="dot" id="dot-audio"></span> マイク</span>
+    <span><span class="dot" id="dot-ws"></span> サーバー</span>
+    <span id="fps-display">-- fps</span>
+    <span id="latency-display">-- ms</span>
+  </div>
+
+  <div class="layout">
+    <!-- Left: video -->
+    <div>
+      <div class="video-area">
+        <video id="video" autoplay playsinline muted></video>
+        <canvas id="canvas"></canvas>
+        <div class="overlay waiting" id="score-overlay">待機中</div>
+      </div>
+      <div class="controls">
+        <button id="btn-start">▶ 開始</button>
+        <button id="btn-stop" style="display:none">⏹ 停止</button>
+      </div>
+    </div>
+
+    <!-- Right: dashboard -->
+    <div class="dashboard">
+      <div class="panel">
+        <h3>総合疲労スコア</h3>
+        <div class="big-score low" id="fatigue-score">0.00</div>
+      </div>
+
+      <div class="panel">
+        <h3>姿勢分類</h3>
+        <div class="meter"><label>良好 (good)</label><div class="bar"><div class="bar-fill" id="bar-good" style="width:0%"></div></div><div class="value" id="val-good">-</div></div>
+        <div class="meter"><label>猫背 (slouch)</label><div class="bar"><div class="bar-fill" id="bar-slouch" style="width:0%"></div></div><div class="value" id="val-slouch">-</div></div>
+        <div class="meter"><label>頬杖 (chin_rest)</label><div class="bar"><div class="bar-fill" id="bar-chin_rest" style="width:0%"></div></div><div class="value" id="val-chin_rest">-</div></div>
+        <div class="meter"><label>ストレッチ</label><div class="bar"><div class="bar-fill" id="bar-stretch" style="width:0%"></div></div><div class="value" id="val-stretch">-</div></div>
+      </div>
+
+      <div class="panel">
+        <h3>🧠 LLM判定</h3>
+        <div class="llm-reasoning" id="llm-reasoning">待機中...</div>
+        <div class="llm-status" id="llm-status"></div>
+      </div>
+
+      <div class="panel">
+        <h3>🎙 音声認識</h3>
+        <div class="transcript" id="transcript">（音声なし）</div>
+        <div class="keyword-alert" id="keyword-alert"></div>
+      </div>
+
+      <div class="panel">
+        <h3>スコア内訳</h3>
+        <div class="meter"><label>姿勢</label><div class="bar"><div class="bar-fill" id="bar-posture" style="width:0%"></div></div><div class="value" id="val-posture">-</div></div>
+        <div class="meter"><label>音声</label><div class="bar"><div class="bar-fill" id="bar-voice" style="width:0%"></div></div><div class="value" id="val-voice">-</div></div>
+        <div class="meter"><label>環境</label><div class="bar"><div class="bar-fill" id="bar-env" style="width:0%"></div></div><div class="value" id="val-env">-</div></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="log" id="log"></div>
+</div>
+
+<script>
+const video = document.getElementById('video');
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+const overlay = document.getElementById('score-overlay');
+const logEl = document.getElementById('log');
+
+let wsVideo = null, wsAudio = null;
+let mediaStream = null, audioRecorder = null;
+let sendInterval = null, isRunning = false;
+let fpsFrames = 0, lastFpsTime = Date.now();
+
+const SERVER = location.host;
+const POSTURE_LABELS = { good: '良好', slouch: '猫背', chin_rest: '頬杖', stretch: 'ストレッチ' };
+
+function addLog(msg, cls = '') {
+  const el = document.createElement('div');
+  el.className = 'entry ' + cls;
+  el.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+  logEl.prepend(el);
+  if (logEl.children.length > 40) logEl.lastChild.remove();
+}
+
+function setDot(id, on) {
+  document.getElementById(id).className = 'dot ' + (on ? 'on' : 'off');
+}
+
+function barColor(v) {
+  if (v < 0.3) return '#4caf50';
+  if (v < 0.6) return '#ffc107';
+  return '#ff5252';
+}
+
+function updateMeter(id, value) {
+  const bar = document.getElementById('bar-' + id);
+  const val = document.getElementById('val-' + id);
+  if (!bar || !val) return;
+  const pct = Math.min(100, Math.round(value * 100));
+  bar.style.width = pct + '%';
+  bar.style.background = barColor(value);
+  val.textContent = value.toFixed(2);
+}
+
+async function startMedia() {
+  try {
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+      video: { width: 640, height: 480, facingMode: 'user' },
+      audio: true,
+    });
+    video.srcObject = mediaStream;
+    setDot('dot-video', true);
+    setDot('dot-audio', true);
+    addLog('カメラ・マイク取得完了', 'info');
+
+    audioRecorder = new MediaRecorder(mediaStream, { mimeType: 'audio/webm;codecs=opus' });
+    audioRecorder.ondataavailable = (e) => {
+      if (wsAudio && wsAudio.readyState === WebSocket.OPEN && e.data.size > 0) {
+        wsAudio.send(e.data);
+      }
+    };
+  } catch (err) {
+    addLog('メディア取得失敗: ' + err.message, 'warn');
+  }
+}
+
+function connectWebSockets() {
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+
+  wsVideo = new WebSocket(`${proto}://${SERVER}/ws/video`);
+  wsVideo.onopen = () => { setDot('dot-ws', true); addLog('Video WS 接続', 'info'); };
+  wsVideo.onclose = () => { setDot('dot-ws', false); addLog('Video WS 切断'); };
+  wsVideo.onmessage = (e) => {
+    const msg = JSON.parse(e.data);
+    if (msg.type !== 'result') return;
+
+    const posture = msg.posture;
+    const fatigue = msg.fatigue;
+    const cls = posture.class;
+    const label = POSTURE_LABELS[cls] || cls;
+    const conf = posture.confidence;
+    const score = fatigue.fatigue_score;
+
+    // Overlay
+    overlay.textContent = `${label} ${(conf * 100).toFixed(0)}%`;
+    overlay.className = 'overlay ' + cls;
+
+    // Fatigue big score
+    const scoreEl = document.getElementById('fatigue-score');
+    scoreEl.textContent = score.toFixed(2);
+    scoreEl.className = 'big-score ' + (score < 0.3 ? 'low' : score < 0.6 ? 'mid' : 'high');
+
+    // Posture class probabilities
+    if (posture.probabilities) {
+      for (const [k, v] of Object.entries(posture.probabilities)) {
+        updateMeter(k, v);
+      }
+    }
+
+    // Score breakdown
+    updateMeter('posture', fatigue.posture_score || 0);
+    updateMeter('voice', fatigue.voice_score || 0);
+    updateMeter('env', fatigue.environment_score || 0);
+
+    // LLM reasoning
+    const reasonEl = document.getElementById('llm-reasoning');
+    const statusEl = document.getElementById('llm-status');
+    if (fatigue.llm_used) {
+      reasonEl.textContent = fatigue.llm_reasoning || '(判定中...)';
+      statusEl.textContent = '✅ LLM判定使用中';
+    } else {
+      reasonEl.textContent = '(ルールベース)';
+      statusEl.textContent = '⚠ LLM未接続';
+    }
+
+    // FPS
+    fpsFrames++;
+    const now = Date.now();
+    if (now - lastFpsTime > 1000) {
+      document.getElementById('fps-display').textContent =
+        Math.round(fpsFrames / ((now - lastFpsTime) / 1000)) + ' fps';
+      fpsFrames = 0;
+      lastFpsTime = now;
+    }
+    document.getElementById('latency-display').textContent = msg.inference_ms + ' ms';
+  };
+
+  wsAudio = new WebSocket(`${proto}://${SERVER}/ws/audio`);
+  wsAudio.binaryType = 'arraybuffer';
+  wsAudio.onopen = () => addLog('Audio WS 接続', 'info');
+  wsAudio.onclose = () => addLog('Audio WS 切断');
+  wsAudio.onmessage = (e) => {
+    const msg = JSON.parse(e.data);
+    if (msg.type === 'voice_result') {
+      document.getElementById('transcript').textContent =
+        msg.transcript || '（音声なし）';
+      const alertEl = document.getElementById('keyword-alert');
+      if (msg.negative_detected) {
+        alertEl.textContent = '⚠ ネガティブ検出: ' + msg.matched_keywords.join(', ');
+      } else {
+        alertEl.textContent = '';
+      }
+    }
+  };
+}
+
+function captureAndSend() {
+  if (!wsVideo || wsVideo.readyState !== WebSocket.OPEN) return;
+  if (video.videoWidth === 0) return;
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  ctx.drawImage(video, 0, 0);
+  const base64 = canvas.toDataURL('image/jpeg', 0.7).split(',')[1];
+  wsVideo.send(JSON.stringify({ type: 'frame', frame: base64 }));
+}
+
+document.getElementById('btn-start').onclick = () => {
+  if (!wsVideo) connectWebSockets();
+  const waitAndStart = () => {
+    if (wsVideo.readyState !== WebSocket.OPEN) { setTimeout(waitAndStart, 100); return; }
+    isRunning = true;
+    document.getElementById('btn-start').style.display = 'none';
+    document.getElementById('btn-stop').style.display = '';
+    addLog('検知開始', 'info');
+    sendInterval = setInterval(captureAndSend, 200);  // ~5fps
+    if (audioRecorder && audioRecorder.state === 'inactive') audioRecorder.start(100);
+  };
+  waitAndStart();
+};
+
+document.getElementById('btn-stop').onclick = () => {
+  isRunning = false;
+  if (sendInterval) { clearInterval(sendInterval); sendInterval = null; }
+  if (audioRecorder && audioRecorder.state === 'recording') audioRecorder.stop();
+  document.getElementById('btn-start').style.display = '';
+  document.getElementById('btn-stop').style.display = 'none';
+  overlay.textContent = '停止';
+  overlay.className = 'overlay waiting';
+  addLog('検知停止');
+};
+
+startMedia();
+</script>
+</body>
+</html>

--- a/app/streaming_server.py
+++ b/app/streaming_server.py
@@ -1,0 +1,307 @@
+"""WebSocket streaming server — remote camera/audio from MacBook browser.
+
+Receives JPEG frames and WebM/Opus audio from a browser client via
+WebSocket, runs posture + fatigue inference on DGX Spark, and returns
+results in real time.
+
+Usage:
+    python app/streaming_server.py
+    → Open http://localhost:8765 in browser (via SSH port-forward)
+"""
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+# Ensure project root is on sys.path
+_project_root = str(Path(__file__).resolve().parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+import cv2
+import numpy as np
+import uvicorn
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+
+from app.inference.posture import PostureInference
+from app.inference.airflow import AirflowInference
+from app.inference.fatigue import FatigueScorer
+from app.inference.audio import AudioBufferAnalyzer
+from app.config import (
+    ARM_SERVER_URL,
+    DEFAULT_DESK_X,
+    DEFAULT_DESK_Y,
+    DEFAULT_DESK_Z,
+    ENABLE_LLM_SCORING,
+    FATIGUE_ARM_THRESHOLD,
+    LLM_MODEL,
+    LLM_TIMEOUT,
+    LLM_WINDOW_SIZE,
+    OLLAMA_HOST,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="空間AIブレイン — ストリーミングサーバー")
+
+# ---------------------------------------------------------------------------
+# Singleton models (initialized on startup)
+# ---------------------------------------------------------------------------
+_posture_model: PostureInference | None = None
+_airflow_model: AirflowInference | None = None
+_fatigue_scorer: FatigueScorer | None = None
+_llm_scorer = None  # LLMFatigueScorer | None
+_audio_analyzer: AudioBufferAnalyzer | None = None
+
+# Shared state
+_latest_voice_result: dict | None = None
+_voice_lock = asyncio.Lock()
+_latest_airflow_result: dict = {}
+_arm_last_trigger: float = 0.0
+_arm_cooldown: float = 30.0
+
+# LLM async state
+_llm_task: asyncio.Task | None = None
+_last_llm_result: dict | None = None
+
+# Client HTML
+_CLIENT_HTML = Path(__file__).parent / "static" / "client.html"
+
+
+@app.on_event("startup")
+async def startup():
+    global _posture_model, _airflow_model, _fatigue_scorer, _llm_scorer
+    global _audio_analyzer, _latest_airflow_result
+
+    logger.info("Loading models...")
+    _posture_model = PostureInference()
+    _airflow_model = AirflowInference()
+    _fatigue_scorer = FatigueScorer()
+    _audio_analyzer = AudioBufferAnalyzer()
+
+    # Pre-compute default airflow result (no sensors on remote MacBook)
+    _latest_airflow_result = _airflow_model.predict_at_point(
+        DEFAULT_DESK_X, DEFAULT_DESK_Y, DEFAULT_DESK_Z,
+        3.0, 24.0, 0.0, 0.0,  # default: ac_speed=3, temp=24, window=closed, layout=0
+    )
+
+    if ENABLE_LLM_SCORING:
+        from app.inference.llm_fatigue import LLMFatigueScorer
+        _llm_scorer = LLMFatigueScorer(
+            ollama_host=OLLAMA_HOST,
+            model_name=LLM_MODEL,
+            timeout=LLM_TIMEOUT,
+            window_size=LLM_WINDOW_SIZE,
+        )
+        logger.info("LLM scorer enabled: %s @ %s", LLM_MODEL, OLLAMA_HOST)
+
+    logger.info("All models loaded.")
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+@app.get("/")
+async def index():
+    if _CLIENT_HTML.exists():
+        return HTMLResponse(_CLIENT_HTML.read_text())
+    return HTMLResponse("<h1>client.html not found</h1>", status_code=404)
+
+
+@app.get("/health")
+async def health():
+    return {
+        "status": "ok",
+        "llm_enabled": _llm_scorer is not None,
+        "llm_available": _llm_scorer.is_available() if _llm_scorer else False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Video WebSocket
+# ---------------------------------------------------------------------------
+@app.websocket("/ws/video")
+async def video_endpoint(ws: WebSocket):
+    await ws.accept()
+    logger.info("[video] Client connected")
+
+    frame_count = 0
+    loop = asyncio.get_event_loop()
+
+    try:
+        async for data in ws.iter_text():
+            msg = json.loads(data)
+            if msg.get("type") != "frame":
+                continue
+
+            jpg_bytes = base64.b64decode(msg["frame"])
+            img = cv2.imdecode(
+                np.frombuffer(jpg_bytes, dtype=np.uint8), cv2.IMREAD_COLOR
+            )
+            if img is None:
+                continue
+
+            frame_count += 1
+            t0 = time.monotonic()
+
+            # Posture inference (blocking but fast ~20ms)
+            posture_result = _posture_model.predict(img)
+
+            # Fatigue scoring (LLM async or rule-based)
+            fatigue_result = await _compute_fatigue(posture_result, loop)
+
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            score = fatigue_result["fatigue_score"]
+
+            # Robot arm trigger
+            await _maybe_trigger_arm(score)
+
+            await ws.send_json({
+                "type": "result",
+                "posture": posture_result,
+                "fatigue": {
+                    "fatigue_score": score,
+                    "posture_score": fatigue_result.get("posture_score", 0),
+                    "voice_score": fatigue_result.get("voice_score", 0),
+                    "environment_score": fatigue_result.get("environment_score", 0),
+                    "synergy_score": fatigue_result.get("synergy_score", 0),
+                    "llm_used": fatigue_result.get("llm_used", False),
+                    "llm_reasoning": fatigue_result.get("llm_reasoning", ""),
+                },
+                "inference_ms": round(elapsed_ms, 1),
+                "frame": frame_count,
+            })
+
+            if frame_count % 30 == 0:
+                logger.info(
+                    "[video] frame=%d posture=%s score=%.2f %s %.0fms",
+                    frame_count, posture_result["class"], score,
+                    "LLM" if fatigue_result.get("llm_used") else "RULE",
+                    elapsed_ms,
+                )
+
+    except WebSocketDisconnect:
+        logger.info("[video] Client disconnected (frames=%d)", frame_count)
+
+
+# ---------------------------------------------------------------------------
+# Audio WebSocket
+# ---------------------------------------------------------------------------
+@app.websocket("/ws/audio")
+async def audio_endpoint(ws: WebSocket):
+    await ws.accept()
+    logger.info("[audio] Client connected")
+
+    chunk_count = 0
+    loop = asyncio.get_event_loop()
+
+    try:
+        async for chunk in ws.iter_bytes():
+            chunk_count += 1
+
+            # Push chunk to analyzer (blocking ffmpeg decode is deferred to analyze())
+            _audio_analyzer.push_chunk(chunk)
+
+            # Run analysis every ~3 seconds (30 chunks at 100ms each)
+            if chunk_count % 30 == 0:
+                voice_result = await loop.run_in_executor(
+                    None, _audio_analyzer.analyze
+                )
+                async with _voice_lock:
+                    global _latest_voice_result
+                    _latest_voice_result = voice_result
+
+                await ws.send_json({"type": "voice_result", **voice_result})
+
+                if voice_result["negative_detected"]:
+                    logger.info(
+                        "[audio] Negative detected: %s (score=%.2f)",
+                        voice_result["matched_keywords"],
+                        voice_result["voice_score"],
+                    )
+            else:
+                await ws.send_json({"type": "audio_ack", "chunk": chunk_count})
+
+    except WebSocketDisconnect:
+        logger.info("[audio] Client disconnected (chunks=%d)", chunk_count)
+
+
+# ---------------------------------------------------------------------------
+# Fatigue computation (async LLM with rule-based fallback)
+# ---------------------------------------------------------------------------
+async def _compute_fatigue(posture_result: dict, loop) -> dict:
+    global _llm_task, _last_llm_result
+
+    async with _voice_lock:
+        voice = _latest_voice_result
+
+    if _llm_scorer is None:
+        return _fatigue_scorer.compute(posture_result, _latest_airflow_result, voice)
+
+    # Collect completed LLM result
+    if _llm_task is not None and _llm_task.done():
+        try:
+            _last_llm_result = _llm_task.result()
+        except Exception:
+            pass
+        _llm_task = None
+
+    # Submit new LLM task if idle
+    if _llm_task is None:
+        _llm_task = asyncio.ensure_future(
+            loop.run_in_executor(
+                None, _llm_scorer.score,
+                posture_result, _latest_airflow_result, voice,
+            )
+        )
+
+    # Return cached LLM result or rule-based fallback
+    if _last_llm_result is not None:
+        return _last_llm_result
+    return _fatigue_scorer.compute(posture_result, _latest_airflow_result, voice)
+
+
+# ---------------------------------------------------------------------------
+# Robot arm trigger
+# ---------------------------------------------------------------------------
+async def _maybe_trigger_arm(score: float) -> None:
+    global _arm_last_trigger
+
+    arm_url = os.getenv("ARM_SERVER_URL", ARM_SERVER_URL)
+    if not arm_url or score < FATIGUE_ARM_THRESHOLD:
+        return
+
+    now = time.time()
+    if now - _arm_last_trigger < _arm_cooldown:
+        return
+
+    _arm_last_trigger = now
+    logger.info("[arm] Triggering candy delivery (score=%.2f)", score)
+
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            await client.post(f"{arm_url}/trigger", json={"fatigue_score": score})
+        logger.info("[arm] Delivery triggered successfully")
+    except Exception as e:
+        logger.warning("[arm] Trigger failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import socket
+    hostname = socket.gethostname()
+    port = int(os.getenv("STREAMING_PORT", "8765"))
+    print(f"\n  空間AIブレイン — ストリーミングサーバー")
+    print(f"  Open in browser: http://{hostname}:{port}")
+    print(f"  SSH port forward: ssh -L {port}:localhost:{port} {hostname}\n")
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/homeassistant/package_stackchan_fatigue.yaml
+++ b/homeassistant/package_stackchan_fatigue.yaml
@@ -15,6 +15,9 @@ shell_command:
   stackchan_fatigue_speech: 'curl -sS -G --max-time 60 "http://stack-chan.local/speech" --data-urlencode "say=おつかれさまやなぁ。あめちゃんたべぇ"'
   stackchan_lego_forward: 'curl -sS --max-time 10 -X POST -d "ch=0&pwm=7&out=b" "http://stack-chan.local/lego"'
   stackchan_lego_stop: 'curl -sS --max-time 10 -X POST -d "ch=0&pwm=0&out=b" "http://stack-chan.local/lego"'
+  # SO-ARM101 candy delivery trigger (DGX Spark上の arm_server.py)
+  # <DGX_SPARK_IP> はデプロイ環境に応じて固定IPに置き換えること
+  soarm_trigger_candy: 'curl -sS --max-time 60 -X POST -H "Content-Type: application/json" -d "{\"fatigue_score\": {{ states(''sensor.kanden_fatigue'') }}}" "http://<DGX_SPARK_IP>:8766/trigger"'
 
 automation:
   - id: fatigue_below_stackchan_neutral
@@ -39,6 +42,8 @@ automation:
     action:
       - service: shell_command.stackchan_fatigue_speech
       - service: shell_command.stackchan_lego_forward
+      # SO-ARM101 飴ちゃんカゴ配達（並行実行）
+      - service: shell_command.soarm_trigger_candy
       - delay:
           seconds: 15
       - service: shell_command.stackchan_lego_stop

--- a/robot/arm_server.py
+++ b/robot/arm_server.py
@@ -1,0 +1,136 @@
+"""SO-ARM101 candy delivery server — triggered by fatigue detection.
+
+Exposes a FastAPI endpoint that, upon receiving a trigger, executes one
+episode of the ACT imitation-learning policy to pick up and deliver a
+candy basket.
+
+Usage:
+    uvicorn robot.arm_server:app --host 0.0.0.0 --port 8766
+
+Requires:
+    - LeRobot (lerobot) installed with ACT policy support
+    - SO-ARM101 leader/follower connected via USB
+    - Trained ACT checkpoint at the path specified in config
+"""
+
+import logging
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from robot.config import (
+    ACT_CHECKPOINT_PATH,
+    CONTROL_FPS,
+    ROBOT_TYPE,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="SO-ARM101 Candy Delivery", version="1.0.0")
+
+# Global lock to prevent concurrent arm operations
+_arm_lock = threading.Lock()
+_arm_running = False
+
+
+class TriggerRequest(BaseModel):
+    fatigue_score: float = 0.0
+
+
+class TriggerResponse(BaseModel):
+    status: str
+    message: str
+    duration_seconds: float = 0.0
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "arm_running": _arm_running}
+
+
+@app.post("/trigger", response_model=TriggerResponse)
+def trigger_candy_delivery(req: TriggerRequest):
+    """Trigger one episode of ACT candy basket delivery.
+
+    Returns immediately if the arm is already running (mode: single).
+    """
+    global _arm_running
+
+    if _arm_running:
+        raise HTTPException(
+            status_code=409,
+            detail="Arm is already executing a delivery. Please wait.",
+        )
+
+    checkpoint = Path(ACT_CHECKPOINT_PATH)
+    if not checkpoint.exists():
+        raise HTTPException(
+            status_code=500,
+            detail=f"ACT checkpoint not found: {checkpoint}",
+        )
+
+    logger.info(
+        "Candy delivery triggered (fatigue_score=%.2f)", req.fatigue_score
+    )
+
+    _arm_running = True
+    start = time.time()
+
+    try:
+        result = subprocess.run(
+            [
+                "python",
+                "-m",
+                "lerobot.scripts.control_robot",
+                f"--robot.type={ROBOT_TYPE}",
+                "--control.type=record",
+                f"--control.fps={CONTROL_FPS}",
+                f"--control.policy.path={ACT_CHECKPOINT_PATH}",
+                "--control.display_data=false",
+                "--control.num_episodes=1",
+                "--control.warmup_time_s=2",
+                "--control.reset_time_s=5",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        duration = time.time() - start
+
+        if result.returncode != 0:
+            logger.error("LeRobot stderr: %s", result.stderr[:500])
+            return TriggerResponse(
+                status="error",
+                message=f"LeRobot exited with code {result.returncode}",
+                duration_seconds=duration,
+            )
+
+        logger.info("Candy delivery completed in %.1fs", duration)
+        return TriggerResponse(
+            status="completed",
+            message="Candy basket delivered successfully!",
+            duration_seconds=duration,
+        )
+
+    except subprocess.TimeoutExpired:
+        logger.error("LeRobot timed out after 120s")
+        return TriggerResponse(
+            status="timeout",
+            message="Arm operation timed out",
+            duration_seconds=time.time() - start,
+        )
+    except Exception as e:
+        logger.exception("Unexpected error during arm operation")
+        return TriggerResponse(
+            status="error",
+            message=str(e),
+            duration_seconds=time.time() - start,
+        )
+    finally:
+        _arm_running = False

--- a/robot/config.py
+++ b/robot/config.py
@@ -1,0 +1,15 @@
+"""Configuration for SO-ARM101 robot arm candy delivery."""
+
+import os
+
+# Robot hardware
+ROBOT_TYPE = os.getenv("ROBOT_TYPE", "so100")
+
+# ACT policy checkpoint path
+ACT_CHECKPOINT_PATH = os.getenv(
+    "ACT_CHECKPOINT_PATH",
+    "outputs/act_candy_basket/checkpoints/last/pretrained_model",
+)
+
+# Control parameters
+CONTROL_FPS = int(os.getenv("CONTROL_FPS", "30"))

--- a/robot/requirements.txt
+++ b/robot/requirements.txt
@@ -1,0 +1,7 @@
+# SO-ARM101 candy delivery server
+fastapi>=0.115.0
+uvicorn>=0.34.0
+pydantic>=2.0.0
+
+# LeRobot (install separately — requires specific PyTorch version)
+# pip install lerobot


### PR DESCRIPTION
## Summary

Issue #19 の実装: ローカルLLM（Ollama）によるエージェントループ型の統合疲労判断と、MacBookからDGX Sparkへのリモートストリーミング、SO-ARM101ロボットアーム連携を追加。

### LLM統合疲労判断
- `app/inference/llm_fatigue.py`: Ollama qwen3:8b によるスライディングウィンドウ(5回)付きエージェントループ
- タイムアウト/エラー時は既存ルールベースFatigueScorerにフォールバック
- `app/main.py`: ThreadPoolExecutorで非同期LLM呼び出し、ダッシュボードにreasoning表示

### WebSocketリモートストリーミング
- `app/streaming_server.py`: FastAPI + WebSocketサーバー（port 8765）
- `app/static/client.html`: ブラウザUI（4クラス姿勢 + 疲労スコア + LLM reasoning + 音声認識）
- `app/inference/audio.py`: AudioBufferAnalyzer追加（WebM/Opus → ffmpeg PCM → faster-whisper）
- MacBook → SSH port forward → DGX Spark で推論

### ロボットアーム連携
- `robot/arm_server.py`: FastAPI POST /trigger → LeRobot ACT推論を1エピソード実行
- `homeassistant/package_stackchan_fatigue.yaml`: HA自動化にアームトリガー追加
- `app/main.py`: サイドバーからアーム直接トリガー対応（HA不要時）

## Test plan
- [ ] DGX Spark で `ollama pull qwen3:8b` → Streamlit 起動 → LLM判定動作確認
- [ ] `python app/streaming_server.py` → MacBookブラウザから接続 → 姿勢+疲労スコア表示
- [ ] 音声認識: "しんどい" 発話 → ネガティブキーワード検出 → 音声スコア上昇
- [ ] `ENABLE_LLM_SCORING=false` → ルールベースフォールバック確認
- [ ] SO-ARM101 テレオペデータ収集 → ACT学習 → arm_server推論テスト
- [ ] E2E: 疲労検知 → LLM判定 → アームトリガー → 飴配達

Closes #19