### PR TITLE
docs: READMEにロボットアーム模倣学習モデル・データセット情報を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@
 | ファイル | `model/airflow/airflow_surrogate.onnx` |
 | HuggingFace | [SeiyaCM/KandenAiHackathonAirflowModel](https://huggingface.co/SeiyaCM/KandenAiHackathonAirflowModel) |
 
+### ロボットアーム模倣学習モデル — ACT (Candy Basket Delivery)
+
+| 項目 | 詳細 |
+|------|------|
+| アルゴリズム | ACT (Action Chunking with Transformers) |
+| Vision Backbone | ResNet18 (ImageNet pretrained) |
+| パラメータ数 | 52M (51,597,190) |
+| フレームワーク | [LeRobot](https://github.com/huggingface/lerobot) v0.4.4 |
+| 学習手法 | 模倣学習（テレオペレーションデータから学習） |
+| 学習ステップ | 100,000 steps |
+| 最終 loss | 0.031 |
+| 入力 | 関節角度 (6DoF) + 俯瞰カメラ画像 (640×480) + グリッパーカメラ画像 (640×480) |
+| 出力 | 6自由度アクション指令値 |
+| 推論FPS | 30Hz (CUDA) — 学習時FPSと一致させることが成功率に直結 |
+| HuggingFace | [himorishige/act_so101_candy_basket](https://huggingface.co/himorishige/act_so101_candy_basket) |
+
 ---
 
 ## 📊 学習データ / Datasets
@@ -105,6 +121,21 @@
 | 生成方法 | OpenFOAM buoyantSimpleFoam CFDシミュレーション |
 | パラメータ | AC風速, AC温度, 窓開閉, 換気量, レイアウト |
 | ライセンス | MIT |
+
+### ロボットアーム テレオペレーションデータセット
+
+[himorishige/so101_candy_basket](https://huggingface.co/datasets/himorishige/so101_candy_basket)
+
+| 項目 | 詳細 |
+|------|------|
+| エピソード数 | 50 |
+| 総フレーム数 | 29,186 |
+| FPS | 30 |
+| フォーマット | LeRobot v3.0（Parquet + MP4） |
+| 収集方法 | テレオペレーション（SO-ARM101 リーダー・フォロワー構成） |
+| カメラ | 俯瞰（Logitech C920）+ グリッパー（InnoMaker U20CAM-1080p） |
+| タスク | 飴ちゃん入りカゴを掴んでユーザーへ運ぶ |
+| ライセンス | Apache-2.0 |
 
 ---
 


### PR DESCRIPTION
## Summary

- モデル情報セクションに ACT 模倣学習モデル（SO-ARM101 飴ちゃんカゴ配達）を追加
- データセットセクションにテレオペレーションデータセットを追加
- HuggingFace リンク: [モデル](https://huggingface.co/himorishige/act_so101_candy_basket) / [データセット](https://huggingface.co/datasets/himorishige/so101_candy_basket)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds documentation tables and Hugging Face links, with no code, dependency, or runtime behavior changes.
> 
> **Overview**
> Adds a new **robot-arm imitation-learning model** entry to `README.md`, documenting the ACT setup (ResNet18 backbone, training steps/loss, inputs/outputs, and inference FPS) and linking to the published Hugging Face model.
> 
> Adds a corresponding **teleoperation dataset** section with collection details (episodes/frames, sensors/cameras, format, and license) and a Hugging Face dataset link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9b60d841f8a8c707983adb16edf994005fc401. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->